### PR TITLE
Add unit test infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Open Logic Gate Simulator
 #### Importing
 
 1. Clone the repository.
-1. Start IntelliJ. From the welcome screen, select *Import Project*. Locate and select the `build.gradle` file in the repository root, then press *OK*.
-1. Click *OK* in the Import Project from Gradle window.
-1. If asked about overwriting the `.idea` project file, select *Yes*.
+2. Start IntelliJ. From the welcome screen, select *Import Project*. Locate and select the `build.gradle` file in the repository root, then press *OK*.
+3. Click *OK* in the Import Project from Gradle window.
+4. If asked about overwriting the `.idea` project file, select *Yes*.
 
 The project is now imported into IntelliJ.
 
@@ -15,12 +15,18 @@ The project is now imported into IntelliJ.
 To be able to run the project, we need to add a run configuration.
 
 1. From the menu select *Run->Edit configurations*. Click the plus (+) button and select Gradle.
-1. Set the following values:
+2. Set the following values:
    * *Name*: OpenLogicGateSimulator
    * *Gradle project*: Press the folder icon and select the OpenLogicGateSimulator project.
    * *Tasks:*: `run` (autocompletion should list this task).
-1. Press *Apply*, then *OK*. You can now select the configuration and run it.
+3. Press *Apply*, then *OK*. You can now select the configuration and run it.
 
 #### Unit tests
-Instructions for running the unit test gradle task:  
-TBD.
+Instructions for setting up and running the unit test gradle task:  
+
+1. From the menu select *Run->Edit configurations*. Click the plus (+) button and select Gradle.
+2. Set the following values:
+   * *Name*: Unit tests
+   * *Gradle project*: Press the folder icon and select the OpenLogicGateSimulator project.
+   * *Tasks:*: `test` (autocompletion should list this task).
+3. Press *Apply*, then *OK*. You can now select the configuration and run it.

--- a/build.gradle
+++ b/build.gradle
@@ -18,16 +18,20 @@ plugins {
 mainClassName = 'org.cafebabe.Main'
 
 dependencies {
-    // This dependency is found on compile classpath of this component and consumers.
-    //compile 'com.google.guava:guava:23.0'
+    testImplementation (
+        'org.junit.jupiter:junit-jupiter-api:5.3.1'
+    )
 
-    // Use JUnit test framework
-    testCompile 'junit:junit:4.12'
+    testRuntimeOnly (
+        'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+    )
 }
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use jcenter for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
     mavenCentral()
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src/test/java/Main.java
+++ b/src/test/java/Main.java
@@ -1,0 +1,12 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MyTests {
+
+    @Test
+    void dummyTest() {
+        System.out.println("### This test method should be run ###");
+        assertEquals(1, 1);
+    }
+}


### PR DESCRIPTION
New unit tests should be added in an appropriate class in src/test/ and
use JUnit5.

Gradle can be used to run the unit tests with `./gradlew test`. See
README.md for instructions on setting up a run configuration for this
from within IntelliJ.

~This should be merged before the travis branch is merged so that automatic
running of unit tests can be added to the Travis config before merge.~
#6 should be merged before this.