### PR TITLE
Add Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: java
+
+jdk:
+  - oraclejdk10
+  - oraclejdk9
+
+script:
+  - ./gradlew build --console 'plain' -s
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+notifications:
+  slack: ly2tda367:WUW6ie2BCsRP8y4XVyklmuWJ


### PR DESCRIPTION
Adds a Travis configuration file to the repo to enable Travis builds for Oracle JDK9 and JDK10.

Builds the project using `./gradlew build`. Running unit tests can be added later, once basic tests are in place.

OpenJDK builds are not planned due to requiring OpenJFX which is not provided by default. The extra work outweighs the extra gain.