### PR TITLE
Travis: change notification settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,9 @@ cache:
     - $HOME/.gradle/wrapper/
 
 notifications:
-  slack: ly2tda367:WUW6ie2BCsRP8y4XVyklmuWJ
+  email: false
+  slack:
+    rooms:
+      - ly2tda367:WUW6ie2BCsRP8y4XVyklmuWJ
+    on_success: never
+    on_failure: always


### PR DESCRIPTION
Disabled email notifications to reduce mailbox spam.
Only send notifications to workspace slack if the build fails, to avoid spam
from many successful builds.