### PR TITLE
Fix drag selection bug

### DIFF
--- a/src/main/java/org/cafebabe/controller/editor/workspace/circuit/CircuitController.java
+++ b/src/main/java/org/cafebabe/controller/editor/workspace/circuit/CircuitController.java
@@ -89,8 +89,8 @@ public class CircuitController extends Controller {
         List<ISelectable> componentsInBounds = new ArrayList<>();
 
         this.view.getComponentViews().forEach(componentView -> {
-            Bounds compBounds = componentView.getBoundsInParent();
-            if (bounds.intersects(compBounds)) {
+
+            if (componentView.isIntersecting(bounds)) {
                 componentsInBounds.add(componentView);
             }
         });

--- a/src/main/java/org/cafebabe/view/editor/workspace/circuit/component/ComponentView.java
+++ b/src/main/java/org/cafebabe/view/editor/workspace/circuit/component/ComponentView.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import javafx.fxml.FXML;
+import javafx.geometry.Bounds;
 import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.paint.Color;
@@ -64,6 +65,7 @@ public class ComponentView extends View implements ISelectable {
 
         SvgContent svg = SvgUtil.loadComponentSvg(component);
         this.componentSvgContainer.getChildren().setAll(svg);
+        svg.setPickOnBounds(false);
 
         svg.selectNodes("component-body").forEachRemaining(
                 ComponentView::setDefaultStyle
@@ -129,6 +131,12 @@ public class ComponentView extends View implements ISelectable {
         return (SvgContent) this.componentSvgContainer.getChildren().get(0);
     }
 
+    public boolean isIntersecting(Bounds bounds) {
+        Bounds localBounds = this.parentToLocal(bounds);
+        Bounds groupBounds = this.svgGroup.parentToLocal(localBounds);
+        Bounds containerBounds = this.componentSvgContainer.parentToLocal(groupBounds);
+        return getComponentSvg().intersects(containerBounds);
+    }
 
     /* Private */
     private static void setDefaultStyle(Node n) {


### PR DESCRIPTION
Fixes #67 

This is as close as we can get it right now. It still doesn't check whether or not the selection box intersects the SVG Path for some reason, but it at least checks a much tighter bounding box, so the bug is much less prominent.