### PR TITLE
Stop simulator when closing workspace

### DIFF
--- a/src/main/java/org/cafebabe/model/editor/Editor.java
+++ b/src/main/java/org/cafebabe/model/editor/Editor.java
@@ -27,6 +27,7 @@ public class Editor {
             throw new WorkspaceNotInEditorException();
         }
 
+        workspace.getCircuit().stopSimulator();
         this.workspaceList.remove(workspace);
     }
 

--- a/src/main/java/org/cafebabe/model/editor/workspace/circuit/Circuit.java
+++ b/src/main/java/org/cafebabe/model/editor/workspace/circuit/Circuit.java
@@ -88,6 +88,10 @@ public class Circuit {
         this.simulator.toggleSimulationState();
     }
 
+    public void stopSimulator() {
+        this.simulator.stop();
+    }
+
     public void registerSimulationStateListener(Consumer<SimulationState> listener) {
         this.simulator.registerSimulationStateListener(listener);
     }


### PR DESCRIPTION
When closing a circuit with a clock and a note component hooked up to it, it kept making sounds after the tab is closed.